### PR TITLE
make html file extension optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ used in webpack-handlebars-static-file-generator
 |`data`| Folder for data.json files. Currently files starting with _ will be ignored in path structure |
 |`rootData`| Root file for data - will be generated without subfolder |
 |`extract`| Return markup as Object instead of writing it to file |
+|`extension`| Append extension to output filename, defaults to `.html` |

--- a/dist/index.js
+++ b/dist/index.js
@@ -31,7 +31,8 @@ module.exports = function (source, map) {
 
   var options = Object.assign({}, {
     partialNamer: _utils.defaultNamer,
-    helperNamer: _utils.defaultHelperNamer
+    helperNamer: _utils.defaultHelperNamer,
+    extension: '.html'
   }, (0, _loaderUtils.getOptions)(this));
 
   if (options.partials) {
@@ -64,7 +65,7 @@ module.exports = function (source, map) {
     }, {});
 
     var routeName = (0, _utils.removeExtension)(_this.resourcePath.substr(_this.resourcePath.indexOf(options['relativePathTo']) + options['relativePathTo'].length));
-    var relativePath = "".concat(options['outputpath']).concat(languagePath).concat(routeName, ".html");
+    var relativePath = "".concat(options['outputpath']).concat(languagePath).concat(routeName).concat((0, _utils.getExtension)(options.extension));
     data = (0, _lodash.default)(data, language.data);
     data.absRefPrefix = (0, _utils.getRelativePath)(relativePath);
     data.language = languageName;

--- a/dist/utils/utils.js
+++ b/dist/utils/utils.js
@@ -7,6 +7,7 @@ exports.defaultHelperNamer = defaultHelperNamer;
 exports.defaultNamer = defaultNamer;
 exports.getRelativePath = getRelativePath;
 exports.removeExtension = removeExtension;
+exports.getExtension = getExtension;
 
 function defaultHelperNamer(file) {
   return defaultNamer(file).replace('.helper', '');
@@ -30,4 +31,18 @@ function getRelativePath(path) {
 
 function removeExtension(path) {
   return path.slice(0, path.lastIndexOf('.'));
+}
+
+function getExtension() {
+  var extension = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+
+  if (typeof extension !== 'string' || extension === '') {
+    return '';
+  }
+
+  if (extension.substr(0, 1) !== '.') {
+    extension = ".".concat(extension);
+  }
+
+  return extension;
 }

--- a/dist/utils/utils.test.js
+++ b/dist/utils/utils.test.js
@@ -18,3 +18,9 @@ test('Test defaultNamer to use folder and name', function () {
 test('Remove helper string from name in register by default', function () {
   expect((0, _utils.defaultHelperNamer)('src/js/helpers/concat.helper.js')).toEqual('helpers/concat');
 });
+test('Get optional file extension', function () {
+  expect((0, _utils.getExtension)(false)).toEqual('');
+  expect((0, _utils.getExtension)({})).toEqual('');
+  expect((0, _utils.getExtension)('.html')).toEqual('.html');
+  expect((0, _utils.getExtension)('html')).toEqual('.html');
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import { getOptions } from 'loader-utils';
-import { defaultNamer, defaultHelperNamer, getRelativePath, removeExtension } from './utils/utils';
+import { defaultNamer, defaultHelperNamer, getRelativePath, removeExtension, getExtension } from './utils/utils';
 import Handlebars from 'handlebars';
 import Helpers from './utils/helpers';
 import merge from 'lodash.merge';
@@ -19,7 +19,8 @@ let resultObject = {};
 module.exports = function(source, map) {
   const options = Object.assign({}, {
     partialNamer: defaultNamer,
-    helperNamer: defaultHelperNamer
+    helperNamer: defaultHelperNamer,
+    extension: '.html'
   }, getOptions(this));
 
   if (options.partials) {
@@ -48,7 +49,7 @@ module.exports = function(source, map) {
 
     let data = _data.reduce((reducedData, dataObject) => merge(reducedData, dataObject), {});
     const routeName = removeExtension(this.resourcePath.substr(this.resourcePath.indexOf(options['relativePathTo']) + options['relativePathTo'].length));
-    const relativePath = `${options['outputpath']}${languagePath}${routeName}.html`;
+    const relativePath = `${options['outputpath']}${languagePath}${routeName}${getExtension(options.extension)}`;
     data = merge(data, language.data);
 
     data.absRefPrefix = getRelativePath(relativePath);

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -20,9 +20,20 @@ function removeExtension(path) {
   return path.slice(0, path.lastIndexOf('.'));
 }
 
+function getExtension(extension = '') {
+  if (typeof extension !== 'string' || extension === '') {
+    return '';
+  }
+  if (extension.substr(0,1) !== '.') {
+    extension = `.${extension}`;
+  }
+  return extension;
+}
+
 export {
   defaultHelperNamer,
   defaultNamer,
   getRelativePath,
-  removeExtension
+  removeExtension,
+  getExtension
 };

--- a/src/utils/utils.test.js
+++ b/src/utils/utils.test.js
@@ -1,5 +1,5 @@
 /* global expect */
-import { removeExtension, getRelativePath, defaultNamer, defaultHelperNamer } from './utils.js';
+import { removeExtension, getRelativePath, defaultNamer, defaultHelperNamer, getExtension } from './utils.js';
 
 test('Remove JS extension from file', () => {
   expect(removeExtension('dist/js/main.js')).toEqual('dist/js/main');
@@ -19,4 +19,11 @@ test('Test defaultNamer to use folder and name', () => {
 
 test('Remove helper string from name in register by default', () => {
   expect(defaultHelperNamer('src/js/helpers/concat.helper.js')).toEqual('helpers/concat');
+});
+
+test('Get optional file extension', () => {
+  expect(getExtension(false)).toEqual('');
+  expect(getExtension({})).toEqual('');
+  expect(getExtension('.html')).toEqual('.html');
+  expect(getExtension('html')).toEqual('.html');
 });


### PR DESCRIPTION
 - write test for getExtension
 - allow any filetypes to be generated
 - defaults to '.html' for backwards compatibility